### PR TITLE
Normalize Krisha URLs and reuse e2e server port

### DIFF
--- a/ai-service/app/domain/value_objects.py
+++ b/ai-service/app/domain/value_objects.py
@@ -20,25 +20,23 @@ class SourceType(str, enum.Enum):
             return candidate
 
         # Accept scheme-less Krisha URLs like "krisha.kz/show/12345".
-        if candidate.lower().startswith(("krisha.kz/", "www.krisha.kz/", "airbnb.", "www.airbnb.")):
+        if candidate.lower().startswith(("krisha.kz/", "www.krisha.kz/", "m.krisha.kz/", "airbnb.", "www.airbnb.")):
             candidate = f"https://{candidate}"
 
         parsed = urlsplit(candidate)
-        host = parsed.netloc.lower()
-        if host.startswith("www."):
-            host_wo_www = host[4:]
-        else:
-            host_wo_www = host
+        host = (parsed.hostname or "").lower()
+        netloc = parsed.netloc
 
-        if host_wo_www == "krisha.kz":
+        if host in {"krisha.kz", "www.krisha.kz", "m.krisha.kz"}:
             match = re.match(r"^/(?:a/)?show/(\d+)/?$", parsed.path)
-            if not match:
-                return candidate
-
-            listing_id = match.group(1)
-            return urlunsplit(("https", "krisha.kz", f"/a/show/{listing_id}", parsed.query, parsed.fragment))
+            canonical_path = parsed.path
+            if match:
+                listing_id = match.group(1)
+                canonical_path = f"/a/show/{listing_id}"
+            return urlunsplit(("https", "krisha.kz", canonical_path, "", ""))
 
         # Accept Airbnb host console links and normalize to room URLs.
+        host_wo_www = host[4:] if host.startswith("www.") else host
         if host_wo_www.startswith("airbnb."):
             room_match = re.match(r"^/rooms/(\d+)(?:/.*)?$", parsed.path)
             editor_match = re.match(r"^/hosting/listings/editor/(\d+)(?:/.*)?$", parsed.path)
@@ -47,7 +45,7 @@ class SourceType(str, enum.Enum):
                 return candidate
 
             listing_id = match.group(1)
-            canonical_host = host or host_wo_www
+            canonical_host = netloc or host_wo_www
             return urlunsplit(("https", canonical_host, f"/rooms/{listing_id}", parsed.query, parsed.fragment))
 
         return candidate

--- a/ai-service/tests/test_domain.py
+++ b/ai-service/tests/test_domain.py
@@ -15,9 +15,17 @@ class TestSourceType:
         url = "krisha.kz/show/690725054"
         assert SourceType.normalize_url(url) == "https://krisha.kz/a/show/690725054"
 
-    def test_normalize_krisha_show_url_preserves_query(self):
+    def test_normalize_krisha_show_url_strips_query(self):
         url = "https://www.krisha.kz/show/690725054?srchid=abc"
-        assert SourceType.normalize_url(url) == "https://krisha.kz/a/show/690725054?srchid=abc"
+        assert SourceType.normalize_url(url) == "https://krisha.kz/a/show/690725054"
+
+    def test_normalize_mobile_krisha_show_url(self):
+        url = "https://m.krisha.kz/show/760869785?srchid=abc&srchtype=filter&srchpos=2"
+        assert SourceType.normalize_url(url) == "https://krisha.kz/a/show/760869785"
+
+    def test_normalize_mobile_krisha_show_url_without_scheme(self):
+        url = "m.krisha.kz/a/show/760869785?srchid=abc"
+        assert SourceType.normalize_url(url) == "https://krisha.kz/a/show/760869785"
 
     def test_normalize_airbnb_hosting_editor_url(self):
         url = "https://www.airbnb.ru/hosting/listings/editor/1502076254219978997/details/photo-tour"
@@ -49,6 +57,10 @@ class TestSourceType:
 
     def test_detect_krisha_url(self):
         url = "https://krisha.kz/a/show/12345"
+        assert SourceType.detect_from_url(url) == SourceType.KRISHA
+
+    def test_detect_mobile_krisha_url(self):
+        url = "https://m.krisha.kz/a/show/12345"
         assert SourceType.detect_from_url(url) == SourceType.KRISHA
 
     def test_detect_krisha_legacy_show_url(self):

--- a/day-backend/app/domain/ai_migration/value_objects.py
+++ b/day-backend/app/domain/ai_migration/value_objects.py
@@ -24,24 +24,22 @@ class ImportSource(str, enum.Enum):
         if not candidate:
             return candidate
 
-        if candidate.lower().startswith(("krisha.kz/", "www.krisha.kz/", "airbnb.", "www.airbnb.")):
+        if candidate.lower().startswith(("krisha.kz/", "www.krisha.kz/", "m.krisha.kz/", "airbnb.", "www.airbnb.")):
             candidate = f"https://{candidate}"
 
         parsed = urlsplit(candidate)
-        host = parsed.netloc.lower()
-        if host.startswith("www."):
-            host_wo_www = host[4:]
-        else:
-            host_wo_www = host
+        host = (parsed.hostname or "").lower()
+        netloc = parsed.netloc
 
-        if host_wo_www == "krisha.kz":
+        if host in {"krisha.kz", "www.krisha.kz", "m.krisha.kz"}:
             match = re.match(r"^/(?:a/)?show/(\d+)/?$", parsed.path)
-            if not match:
-                return candidate
+            canonical_path = parsed.path
+            if match:
+                listing_id = match.group(1)
+                canonical_path = f"/a/show/{listing_id}"
+            return urlunsplit(("https", "krisha.kz", canonical_path, "", ""))
 
-            listing_id = match.group(1)
-            return urlunsplit(("https", "krisha.kz", f"/a/show/{listing_id}", parsed.query, parsed.fragment))
-
+        host_wo_www = host[4:] if host.startswith("www.") else host
         if host_wo_www.startswith("airbnb."):
             room_match = re.match(r"^/rooms/(\d+)(?:/.*)?$", parsed.path)
             editor_match = re.match(r"^/hosting/listings/editor/(\d+)(?:/.*)?$", parsed.path)
@@ -50,7 +48,7 @@ class ImportSource(str, enum.Enum):
                 return candidate
 
             listing_id = match.group(1)
-            canonical_host = host or host_wo_www
+            canonical_host = netloc or host_wo_www
             return urlunsplit(("https", canonical_host, f"/rooms/{listing_id}", parsed.query, parsed.fragment))
 
         return candidate

--- a/day-backend/tests/test_ai_migration_domain.py
+++ b/day-backend/tests/test_ai_migration_domain.py
@@ -43,9 +43,17 @@ class TestImportSource:
     def test_normalize_krisha_legacy_show_url_without_scheme(self):
         assert ImportSource.normalize_url("krisha.kz/show/2303047") == "https://krisha.kz/a/show/2303047"
 
-    def test_normalize_krisha_preserves_query(self):
+    def test_normalize_krisha_strips_query(self):
         url = "https://www.krisha.kz/show/2303047?srchid=abc"
-        assert ImportSource.normalize_url(url) == "https://krisha.kz/a/show/2303047?srchid=abc"
+        assert ImportSource.normalize_url(url) == "https://krisha.kz/a/show/2303047"
+
+    def test_normalize_mobile_krisha_url(self):
+        url = "https://m.krisha.kz/show/760869785?srchid=abc&srchtype=filter&srchpos=2"
+        assert ImportSource.normalize_url(url) == "https://krisha.kz/a/show/760869785"
+
+    def test_normalize_mobile_krisha_url_without_scheme(self):
+        url = "m.krisha.kz/a/show/760869785?srchid=abc"
+        assert ImportSource.normalize_url(url) == "https://krisha.kz/a/show/760869785"
 
     def test_normalize_airbnb_hosting_editor_url(self):
         url = "https://www.airbnb.ru/hosting/listings/editor/1502076254219978997/details/photo-tour"
@@ -99,6 +107,7 @@ class TestImportSource:
         urls = [
             "https://krisha.kz/a/show/12345",
             "https://www.krisha.kz/a/show/67890",
+            "https://m.krisha.kz/a/show/22222",
             "http://krisha.kz/a/show/11111",
         ]
         for url in urls:

--- a/day-frontend/playwright.config.ts
+++ b/day-frontend/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from '@playwright/test'
 
-const reuseBackendServer = process.env.PW_REUSE_BACKEND === '1'
+const reuseLocalServer = !process.env.CI
 
 export default defineConfig({
   testDir: './tests',
@@ -33,14 +33,13 @@ export default defineConfig({
       command:
         "cd ../day-backend && env $(cat local.env | grep -v '^#' | xargs) uv run --with-requirements requirements.txt uvicorn app.main:app --host 0.0.0.0 --port 8000",
       url: 'http://localhost:8000/api/v1/properties',
-      // Keep strict mode by default; opt in for existing local backend when needed.
-      reuseExistingServer: reuseBackendServer,
+      reuseExistingServer: reuseLocalServer,
       timeout: 30_000,
     },
     {
       command: 'npm run dev',
       url: 'http://localhost:3000',
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: reuseLocalServer,
       timeout: 30_000,
     },
   ],

--- a/day-frontend/src/components/ai-import/ImportForm.tsx
+++ b/day-frontend/src/components/ai-import/ImportForm.tsx
@@ -40,12 +40,13 @@ export default function ImportForm({ onSubmit, isLoading }: Props) {
   const [url, setUrl] = useState('')
   const [prompt, setPrompt] = useState('')
 
+  const normalizedUrl = useMemo(() => normalizeInputUrl(url), [url])
+  const isValidUrl = useMemo(() => isHttpUrl(normalizedUrl), [normalizedUrl])
   const sourceType = useMemo(() => detectSourceType(url), [url])
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
-    const normalizedUrl = normalizeInputUrl(url)
-    if (!isHttpUrl(normalizedUrl)) return
+    if (!isValidUrl) return
     onSubmit(normalizedUrl, prompt.trim() || undefined)
   }
 
@@ -62,7 +63,7 @@ export default function ImportForm({ onSubmit, isLoading }: Props) {
             type="url"
             inputMode="url"
             value={url}
-            onChange={(e) => setUrl(e.target.value)}
+            onChange={(e) => setUrl(normalizeInputUrl(e.target.value))}
             placeholder={t('aiImport.urlPlaceholder')}
             required
             className="w-full bg-gray-50 border border-gray-200 rounded-xl p-3 pl-9 pr-28 outline-none focus:ring-2 focus:ring-black/10 text-gray-800 text-sm"
@@ -95,7 +96,7 @@ export default function ImportForm({ onSubmit, isLoading }: Props) {
       <motion.button
         whileTap={{ scale: 0.97 }}
         type="submit"
-        disabled={isLoading || !url.trim()}
+        disabled={isLoading || !isValidUrl}
         className="flex items-center justify-center gap-2 w-full bg-black text-white hover:bg-gray-800 rounded-xl px-6 py-2.5 font-semibold shadow-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {isLoading ? (

--- a/day-frontend/src/utils/url.test.ts
+++ b/day-frontend/src/utils/url.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { isHttpUrl, normalizeInputUrl } from './url'
+
+describe('normalizeInputUrl', () => {
+  it('adds https for scheme-less krisha url and strips query params', () => {
+    const raw = 'krisha.kz/a/show/682796582?srchid=abc&srchtype=hot_block_filter&srchpos=1'
+    expect(normalizeInputUrl(raw)).toBe('https://krisha.kz/a/show/682796582')
+  })
+
+  it('canonicalizes m.krisha.kz host, legacy /show path and strips query params', () => {
+    const raw = 'https://m.krisha.kz/show/760869785?srchid=abc&srchtype=filter&srchpos=2'
+    expect(normalizeInputUrl(raw)).toBe('https://krisha.kz/a/show/760869785')
+  })
+
+  it('keeps non-krisha http urls as is', () => {
+    const raw = 'https://www.booking.com/hotel/kz/test-property.html'
+    expect(normalizeInputUrl(raw)).toBe(raw)
+  })
+})
+
+describe('isHttpUrl', () => {
+  it('treats scheme-less krisha url as valid after normalization', () => {
+    expect(isHttpUrl('m.krisha.kz/a/show/760869785?srchid=abc')).toBe(true)
+  })
+
+  it('rejects non-http schemes', () => {
+    expect(isHttpUrl('javascript:alert(1)')).toBe(false)
+  })
+})

--- a/day-frontend/src/utils/url.ts
+++ b/day-frontend/src/utils/url.ts
@@ -1,12 +1,44 @@
 const SCHEME_RE = /^[a-z][a-z\d+.-]*:\/\//i
-const DOMAIN_LIKE_RE = /^(?:www\.)?[a-z0-9.-]+\.[a-z]{2,}(?:[/:?#].*)?$/i
+const DOMAIN_LIKE_RE = /^(?:www\.|m\.)?[a-z0-9.-]+\.[a-z]{2,}(?::\d+)?(?:[/:?#].*)?$/i
+
+const KRISHA_HOST_ALIASES = new Set(['krisha.kz', 'www.krisha.kz', 'm.krisha.kz'])
+const KRISHA_SHOW_PATH_RE = /^\/(?:a\/)?show\/(\d+)\/?$/i
+
+function canonicalizeKnownHosts(candidate: string): string {
+  try {
+    const parsed = new URL(candidate)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return candidate
+
+    if (!KRISHA_HOST_ALIASES.has(parsed.hostname.toLowerCase())) return candidate
+
+    parsed.protocol = 'https:'
+    parsed.hostname = 'krisha.kz'
+
+    const krishaShowMatch = parsed.pathname.match(KRISHA_SHOW_PATH_RE)
+    if (krishaShowMatch) {
+      parsed.pathname = `/a/show/${krishaShowMatch[1]}`
+    }
+
+    // Tracking params are noisy and not needed for parsing/import.
+    parsed.search = ''
+    parsed.hash = ''
+
+    return parsed.toString()
+  } catch {
+    return candidate
+  }
+}
 
 export function normalizeInputUrl(raw: string): string {
   const value = raw.trim()
   if (!value) return value
 
-  if (SCHEME_RE.test(value)) return value
-  if (DOMAIN_LIKE_RE.test(value)) return `https://${value}`
+  if (SCHEME_RE.test(value)) {
+    return canonicalizeKnownHosts(value)
+  }
+  if (DOMAIN_LIKE_RE.test(value)) {
+    return canonicalizeKnownHosts(`https://${value}`)
+  }
 
   return value
 }

--- a/day-frontend/tests/e2e/ai-import.spec.ts
+++ b/day-frontend/tests/e2e/ai-import.spec.ts
@@ -138,6 +138,29 @@ test.describe('AI Import - E2E', () => {
     expect(importResponse).not.toBeNull()
   })
 
+  test('submit import form normalizes mobile krisha URL without scheme', async ({ page }) => {
+    await page.goto('/ai-import')
+    await page.waitForLoadState('networkidle')
+
+    const rawUrl = 'm.krisha.kz/show/760869785?srchid=abc&srchtype=filter&srchpos=2'
+    const normalizedUrl = 'https://krisha.kz/a/show/760869785'
+
+    const urlInput = page.locator('#import-url, input[type="url"]').first()
+    await urlInput.fill(rawUrl)
+    await expect(urlInput).toHaveValue(normalizedUrl, { timeout: 3000 })
+
+    const requestPromise = page.waitForRequest(
+      (request) => request.url().includes('/api/v1/ai/import') && request.method() === 'POST',
+      { timeout: 10000 },
+    )
+
+    await page.locator('form button[type="submit"]').first().click()
+
+    const request = await requestPromise
+    const payload = request.postDataJSON() as { source_url?: string }
+    expect(payload.source_url).toBe(normalizedUrl)
+  })
+
   test('form validation prevents submission of invalid URL', async ({ page }) => {
     await page.goto('/ai-import')
     await page.waitForLoadState('networkidle')
@@ -149,7 +172,23 @@ test.describe('AI Import - E2E', () => {
     await urlInput.fill('not-a-valid-url')
 
     if (await submitBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+      const isDisabled = await submitBtn.isDisabled()
+      if (isDisabled) {
+        expect(isDisabled).toBeTruthy()
+        return
+      }
+
+      const requestPromise = page
+        .waitForRequest(
+          (request) => request.url().includes('/api/v1/ai/import') && request.method() === 'POST',
+          { timeout: 2000 },
+        )
+        .then(() => true)
+        .catch(() => false)
+
       await submitBtn.click()
+      const requestSent = await requestPromise
+      expect(requestSent).toBeFalsy()
 
       // Either browser validation prevents submission (type="url") or an error appears
       const hasError = await page.getByText(/invalid|valid url|enter.*url/i)


### PR DESCRIPTION
Summary
- strip query parameters from Krisha property URLs before parsing so normalized urls stay stable
- allow the e2e suite to reuse the already-assigned localhost:8000 server instead of failing on port contention

Testing
- Not run (not requested)